### PR TITLE
Add Render Component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,6 @@ FetchContent_Declare(SFML
     SYSTEM)
 FetchContent_MakeAvailable(SFML)
 
-add_executable(main src/main.cpp src/Game.cpp src/GameObject.cpp src/GameObjects/Player.cpp  src/Component.h src/Components/TransformComponent.h src/Components/TransformComponent.cpp)
+add_executable(main "src/main.cpp" "src/Game.cpp" "src/GameObject.cpp" "src/GameObjects/Player.cpp" "src/BaseComponent.h" "src/Components/TransformComponent.h" "src/Components/TransformComponent.cpp" "src/Components/RenderComponent.h" "src/Components/RenderComponent.cpp" "src/DrawableEntity.h" "src/DrawableEntity.cpp")
 target_compile_features(main PRIVATE cxx_std_17)
 target_link_libraries(main PRIVATE SFML::Graphics)

--- a/src/BaseComponent.h
+++ b/src/BaseComponent.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <SFML/Graphics.hpp>
 
 class GameObject;

--- a/src/Component.h
+++ b/src/Component.h
@@ -4,6 +4,8 @@ class GameObject;
 
 class BaseComponent {
 public:
+    GameObject* getOwner() { return owner; }
+
     BaseComponent(GameObject* owner) { setOwner(owner); };
     virtual ~BaseComponent() = default;
     virtual void update(float) {}

--- a/src/Components/RenderComponent.cpp
+++ b/src/Components/RenderComponent.cpp
@@ -1,0 +1,32 @@
+#include "RenderComponent.h"
+
+RenderComponent::RenderComponent(GameObject* owner) : BaseComponent(owner)
+{
+}
+
+RenderComponent::~RenderComponent()
+{
+	delete drawableEntity;
+	drawableEntity = nullptr;
+}
+
+void RenderComponent::interpolate(float alpha)
+{
+	if (!drawableEntity)
+		return;
+
+	TransformComponent* transform = owner->transform;
+	if (transform) {
+		drawableEntity->setPosition(transform->getInterpolatedPosition());
+		drawableEntity->setRotation(sf::degrees(transform->getInterpolatedRotation()));
+		drawableEntity->setScale(transform->getInterpolatedScale());
+	}
+}
+
+void RenderComponent::render(sf::RenderWindow& window)
+{
+	if (!drawableEntity)
+		return;
+
+	window.draw(*drawableEntity);
+}

--- a/src/Components/RenderComponent.h
+++ b/src/Components/RenderComponent.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "../BaseComponent.h"
+#include "../GameObject.h"
+#include <SFML/Graphics.hpp>
+#include "../DrawableEntity.h"
+
+
+class TransformComponent;
+
+class RenderComponent : public BaseComponent {
+private:
+
+public:
+    DrawableEntity* drawableEntity = nullptr;
+
+    RenderComponent(GameObject* owner);
+    virtual ~RenderComponent();
+
+    virtual void interpolate(float) override;
+    void render(sf::RenderWindow& window) override;
+};

--- a/src/Components/TransformComponent.h
+++ b/src/Components/TransformComponent.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "../Component.h"
+#include "../BaseComponent.h"
 #include <SFML/Graphics.hpp>
 
 class TransformComponent : public BaseComponent {

--- a/src/DrawableEntity.cpp
+++ b/src/DrawableEntity.cpp
@@ -1,0 +1,17 @@
+#include "DrawableEntity.h"
+
+DrawableEntity::DrawableEntity(sf::Drawable* drawable): m_drawable(drawable) {
+
+}
+
+DrawableEntity::~DrawableEntity() {
+    delete m_drawable;
+    m_drawable = nullptr;
+}
+
+void DrawableEntity::draw(sf::RenderTarget& target, sf::RenderStates states) const {
+    states.transform *= getTransform();
+
+    if (m_drawable)
+        target.draw(*m_drawable, states);
+}

--- a/src/DrawableEntity.h
+++ b/src/DrawableEntity.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+
+
+class DrawableEntity : public sf::Drawable, public sf::Transformable {
+public:
+    DrawableEntity(sf::Drawable* drawable);
+    ~DrawableEntity() override;
+
+private:
+    void draw(sf::RenderTarget& target, sf::RenderStates states) const override;
+
+    sf::Drawable* m_drawable;
+};

--- a/src/GameObjects/Player.cpp
+++ b/src/GameObjects/Player.cpp
@@ -1,8 +1,11 @@
 #include "Player.h"
 
 Player::Player() {
-    circle = sf::CircleShape(50.0f);
-    circle.setFillColor(sf::Color::Green);
+    sf::CircleShape* circle = new sf::CircleShape(50.0f);
+    circle->setFillColor(sf::Color::Green);
+
+    RenderComponent* render = addComponent<RenderComponent>();
+    render->drawableEntity = new DrawableEntity(circle);
 }
 
 Player::~Player() {
@@ -24,15 +27,4 @@ void Player::fixedUpdate(float deltaTime) {
 
     velocity = movementMultiplier * velocity;
     transform->position += velocity * deltaTime;
-}
-
-void Player::preRender(float alpha)
-{
-    GameObject::preRender(alpha);
-    circle.setPosition(transform->getInterpolatedPosition());
-}
-
-void Player::render(sf::RenderWindow& window) {
-    GameObject::render(window);
-    window.draw(circle);
 }

--- a/src/GameObjects/Player.h
+++ b/src/GameObjects/Player.h
@@ -2,16 +2,14 @@
 
 #include <SFML/Graphics.hpp>
 #include "../GameObject.h"
+#include "../Components/RenderComponent.h"
 
 class Player : public GameObject {
 private:
-    sf::CircleShape circle;
     float movementMultiplier = 300;
     sf::Vector2f velocity;
 public:
     Player();
     virtual ~Player();
     void fixedUpdate(float deltaTime) override;
-    void preRender(float alpha) override;
-    void render(sf::RenderWindow& window) override;
 };


### PR DESCRIPTION
closes #13 

Changes:
- Rename `Component` to `BaseComponent`
- Add getter for `owner` in `BaseComponent`
- Create `DrawableEntity` for handling transformable drawables
- Create `RenderComponent` for handling rendering
- Refactor `Player` to implement `RenderComponent`